### PR TITLE
Removes unnecessary indenter. Uses support in libpak & bard to indent output

### DIFF
--- a/rustup/build.go
+++ b/rustup/build.go
@@ -17,9 +17,7 @@
 package rustup
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -118,39 +116,4 @@ func AppendToPath(values ...string) error {
 	}
 	path = append(path, values...)
 	return os.Setenv("PATH", strings.Join(path, string(os.PathListSeparator)))
-}
-
-// IndentWriter wraps a writer and indents to a given shiftwidth
-type IndentWriter struct {
-	Shift  []byte
-	Writer io.Writer
-	first  bool
-}
-
-func NewIndentWriter(shiftwidth int, writer io.Writer) *IndentWriter {
-	buf := []byte{}
-	for i := 0; i < shiftwidth; i++ {
-		buf = append(buf, ' ')
-	}
-
-	if writer == nil {
-		writer = io.Discard
-	}
-
-	return &IndentWriter{
-		Shift:  buf,
-		Writer: writer,
-		first:  true,
-	}
-}
-
-func (w *IndentWriter) Write(p []byte) (n int, err error) {
-	a := bytes.SplitAfter(p, []byte("\n"))
-	if w.first {
-		w.first = false
-		a = append([][]byte{{}}, a...)
-	}
-	data := bytes.Join(a, w.Shift)
-	i, err := w.Writer.Write(data)
-	return i - (len(data) - len(p)), err
 }

--- a/rustup/build_test.go
+++ b/rustup/build_test.go
@@ -17,14 +17,12 @@
 package rustup_test
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
-	"github.com/paketo-buildpacks/libpak/effect"
 	"github.com/paketo-community/rustup/rustup"
 	"github.com/sclevine/spec"
 )
@@ -36,59 +34,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		build rustup.Build
 		ctx   libcnb.BuildContext
 	)
-
-	context("writer indents", func() {
-		it("indents by 2", func() {
-			buf := bytes.Buffer{}
-			writer := rustup.NewIndentWriter(2, &buf)
-
-			_, err := writer.Write([]byte("hello\nworld!"))
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(buf.String()).To(Equal("  hello\n  world!"))
-		})
-
-		it("indents by 2", func() {
-			buf := bytes.Buffer{}
-			writer := rustup.NewIndentWriter(2, &buf)
-
-			_, err := writer.Write([]byte(`foo
-bar
-baz
-should
-be
-indented`))
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(buf.String()).To(Equal(`  foo
-  bar
-  baz
-  should
-  be
-  indented`))
-		})
-
-		it("indents by 2", func() {
-			buf := bytes.Buffer{}
-			writer := rustup.NewIndentWriter(2, &buf)
-
-			err := effect.NewExecutor().Execute(effect.Execution{
-				Command: "echo",
-				Args:    []string{"-n", "a\nb\n\nc\n   d"},
-				Stdout:  writer,
-				Stderr:  writer,
-			})
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(buf.String()).To(Equal("  a\r\n  b\r\n  \r\n  c\r\n     d"))
-		})
-
-		it("nil writer", func() {
-			writer := rustup.NewIndentWriter(2, nil)
-			_, err := writer.Write([]byte("hello\nworld!"))
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
 
 	context("default libc", func() {
 		it.Before(func() {

--- a/rustup/rust.go
+++ b/rustup/rust.go
@@ -95,8 +95,8 @@ func (r Rust) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 				r.Toolchain,
 			},
 			Dir:    layer.Path,
-			Stdout: NewIndentWriter(6, r.Logger.InfoWriter()),
-			Stderr: NewIndentWriter(6, r.Logger.InfoWriter()),
+			Stdout: bard.NewWriter(r.Logger.Logger.InfoWriter(), bard.WithIndent(3)),
+			Stderr: bard.NewWriter(r.Logger.Logger.InfoWriter(), bard.WithIndent(3)),
 		}); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to run `rustup`\n%w", err)
 		}

--- a/rustup/rustup.go
+++ b/rustup/rustup.go
@@ -78,8 +78,8 @@ func (r Rustup) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 				fmt.Sprintf("--profile=%s", r.Profile),
 			},
 			Dir:    layer.Path,
-			Stdout: NewIndentWriter(6, r.Logger.DebugWriter()),
-			Stderr: NewIndentWriter(6, r.Logger.DebugWriter()),
+			Stdout: bard.NewWriter(r.Logger.Logger.InfoWriter(), bard.WithIndent(3)),
+			Stderr: bard.NewWriter(r.Logger.Logger.InfoWriter(), bard.WithIndent(3)),
 		}); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to run rustup-init\n%w", err)
 		}


### PR DESCRIPTION
Indent output from commands which get executed. This keeps the output neat & tidy.