### PR TITLE
Adds dependency to pipeline descriptor for updating the dependency

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -15,3 +15,15 @@ docker_credentials:
   - registry: docker.io
     username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
     password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+
+dependencies:
+- id:   rustup-gnu
+  uses: docker://ghcr.io/paketo-buildpacks/actions/rustup-init-dependency:main
+  with:
+    target: x86_64-unknown-linux-gnu
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+- id:   rustup-musl
+  uses: docker://ghcr.io/paketo-buildpacks/actions/rustup-init-dependency:main
+  with:
+    target: x86_64-unknown-linux-musl
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This will enable the bot to submit PRs to update the buildpack when new versions of `rustup-init` are released.