### PR TITLE
Fix BP_RUSTUP_ENABLED=false

### DIFF
--- a/rustup/build_test.go
+++ b/rustup/build_test.go
@@ -98,6 +98,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 					Expect(result.Layers).To(HaveLen(0))
 					Expect(result.BOM.Entries).To(HaveLen(0))
+					Expect(result.Unmet).To(HaveLen(1))
+					Expect(result.Unmet[0].Name).To(Equal("rust"))
 				})
 			})
 


### PR DESCRIPTION
With this in place, you can now put the rustup buildpack in front of rust-dist buildpack and the user can disable rustup if they want to use rustup. Previously, this would have failed with neither buildpack running.

Resolves #35.

Merge after #45 