### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ The buildpack will do the following:
 * Executes `rustup` to install a Rust toolchain to a layer marked `build` and `cache` with installed commands on `$PATH`
 
 ## Configuration
-| Environment Variable      | Description                                                                                                                                                                                                                                                                  |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `$BP_RUSTUP_ENABLED`      | Configure rustup to be enabled. This means that rustup will be used to install Rust. Default value is `true`. Set to false to use another Rust toolchain provider like [rust-dist](https://github.com/paketo-community/rust-dist).                                           |
-| `$BP_RUST_TOOLCHAIN`      | Rust toolchain to install. Default `stable`. Other common values: `beta`, `nightly` or a specific versin number. Any [acceptable value for a toolchain](https://dev-doc.rust-lang.org/beta/edition-guide/rust-2018/rustup-for-managing-rust-versions.html) can be used here. |
-| `$BP_RUST_PROFILE`        | Rust profile to install. Default `minimum`. Other acceptable values: `default`, `complete`. See [Rustup docs for profile](https://rust-lang.github.io/rustup/concepts/profiles.html).                                                                                        |
-| `$BP_RUSTUP_INIT_VERSION` | Configure the version of rustup-init to install. It can be a specific version or a wildcard like `1.*`. It defaults to the latest `1.*` version.                                                                                                                             |
-| `$BP_RUSTUP_INIT_LIBC`    | Configure the libc implementation used by the installed toolchain. Available options: `gnu` or `musl`. Defaults to `gnu` for compatiblity.                                                                                                                                   |
+
+| Environment Variable      | Description                                                                                                                                                                                                                                                                              |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$BP_RUSTUP_ENABLED`      | Configure rustup to be enabled. This means that rustup will be used to install Rust. Default value is `true`. Set to false to use another Rust toolchain provider like [rust-dist](https://github.com/paketo-community/rust-dist).                                                       |
+| `$BP_RUST_TOOLCHAIN`      | Rust toolchain to install. Default `stable`. Other common values: `beta`, `nightly` or a specific versin number. Any [acceptable value for a toolchain](https://dev-doc.rust-lang.org/beta/edition-guide/rust-2018/rustup-for-managing-rust-versions.html) can be used here.             |
+| `$BP_RUST_PROFILE`        | Rust profile to install. Default `minimum`. Other acceptable values: `default`, `complete`. See [Rustup docs for profile](https://rust-lang.github.io/rustup/concepts/profiles.html).                                                                                                    |
+| `$BP_RUSTUP_INIT_VERSION` | Configure the version of rustup-init to install. It can be a specific version or a wildcard like `1.*`. It defaults to the latest `1.*` version.                                                                                                                                         |
+| `$BP_RUSTUP_INIT_LIBC`    | Configure the libc implementation used by the installed toolchain. Available options: `gnu` or `musl`. Defaults to `gnu` for compatiblity. You do not need to set this option with the Paketo full/base/tiny stacks. It can be used for compatibility with more exotic or custom stacks. |
+
 
 ## License
 


### PR DESCRIPTION
Clarify usage of `$BP_RUSTUP_INIT_LIBC`, or rather that it's not usually required.