### PR TITLE
Fixes update bug with rustup-init

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -17,12 +17,12 @@ docker_credentials:
     password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
 
 dependencies:
-- id:   rustup-gnu
+- id:   rustup-init-gnu
   uses: docker://ghcr.io/paketo-buildpacks/actions/rustup-init-dependency:main
   with:
     target: x86_64-unknown-linux-gnu
     token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-- id:   rustup-musl
+- id:   rustup-init-musl
   uses: docker://ghcr.io/paketo-buildpacks/actions/rustup-init-dependency:main
   with:
     target: x86_64-unknown-linux-musl

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -44,7 +44,7 @@ jobs:
                   "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
                 | tar -C "${HOME}/bin" -xz crane
               env:
-                CRANE_VERSION: 0.10.0
+                CRANE_VERSION: 0.8.0
             - name: Install pack
               run: |
                 #!/usr/bin/env bash

--- a/.github/workflows/update-rustup-init-gnu.yml
+++ b/.github/workflows/update-rustup-init-gnu.yml
@@ -1,4 +1,4 @@
-name: Update rustup-gnu
+name: Update rustup-init-gnu
 "on":
     schedule:
         - cron: 0 5 * * 1-5
@@ -88,7 +88,7 @@ jobs:
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
-                ID: rustup-gnu
+                ID: rustup-init-gnu
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: ""
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
@@ -98,14 +98,14 @@ jobs:
             - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }} <${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}@users.noreply.github.com>
-                body: Bumps `rustup-gnu` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
-                branch: update/buildpack/rustup-gnu
+                body: Bumps `rustup-init-gnu` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/rustup-init-gnu
                 commit-message: |-
-                    Bump rustup-gnu from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                    Bump rustup-init-gnu from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
 
-                    Bumps rustup-gnu from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                    Bumps rustup-init-gnu from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
                 delete-branch: true
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
-                title: Bump rustup-gnu from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                title: Bump rustup-init-gnu from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/update-rustup-init-musl.yml
+++ b/.github/workflows/update-rustup-init-musl.yml
@@ -1,4 +1,4 @@
-name: Update rustup-musl
+name: Update rustup-init-musl
 "on":
     schedule:
         - cron: 0 5 * * 1-5
@@ -88,7 +88,7 @@ jobs:
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
-                ID: rustup-musl
+                ID: rustup-init-musl
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: ""
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
@@ -98,14 +98,14 @@ jobs:
             - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }} <${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}@users.noreply.github.com>
-                body: Bumps `rustup-musl` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
-                branch: update/buildpack/rustup-musl
+                body: Bumps `rustup-init-musl` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/rustup-init-musl
                 commit-message: |-
-                    Bump rustup-musl from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                    Bump rustup-init-musl from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
 
-                    Bumps rustup-musl from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                    Bumps rustup-init-musl from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
                 delete-branch: true
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
-                title: Bump rustup-musl from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                title: Bump rustup-init-musl from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
The dependency id was not correct in pipeline-descriptor, thus updates were being detected but not reflected into buildpack.toml. This change syncs up pipeline-descriptor.yml with the id names in buildpack.toml.

After this completes, we need to run the two update jobs as there are pending updates we are missing.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>