### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-community/rustup`
 
-The Paketo Rustup Buildpack is a Cloud Native Buildpack that installs and executes `rustup` to install Rust.
+The Paketo Buildpack for Rustup is a Cloud Native Buildpack that installs and executes `rustup` to install Rust.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-community/rustup"
   id = "paketo-community/rustup"
   keywords = ["rust", "rustup"]
-  name = "Paketo Rustup Buildpack"
+  name = "Paketo Buildpack for Rustup"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Rename the buildpack to implement [RFC 0050](https://github.com/paketo-buildpacks/rfcs/issues/233), using the form `Paketo Buildpack for XYZ`.
